### PR TITLE
Add ability to declare craype_link_type

### DIFF
--- a/etc/spack/defaults/cray/packages.yaml
+++ b/etc/spack/defaults/cray/packages.yaml
@@ -2,6 +2,7 @@ packages:
     all:
         compiler: [intel@17.0.2.174, gcc@6.3.0, cce@8.5.4]
         variants: ~shared
+        craype_link_type: "static"
         providers:
             mpi: [mpich]
             mkl: [intel-mkl]

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -28,6 +28,7 @@ import llnl.util.tty as tty
 from spack import build_env_path
 from spack.util.executable import which
 from spack.architecture import Platform, Target, NoPlatformError
+import spack.config
 from spack.operating_systems.linux_distro import LinuxDistro
 from spack.operating_systems.cnl import Cnl
 from llnl.util.filesystem import join_path
@@ -108,8 +109,15 @@ class Cray(Platform):
         """ Change the linker to default dynamic to be more
             similar to linux/standard linker behavior
         """
-        env.set('CRAYPE_LINK_TYPE', 'dynamic')
+        packages = spack.config.get_config("packages")
+        link_type = packages.get(pkg.name, {}).get("craype_link_type", "")
+        if not link_type:
+            link_type = packages.get("all").get("craype_link_type")
+        if not link_type:
+            link_type = "dynamic"
+        env.set('CRAYPE_LINK_TYPE', link_type)
         cray_wrapper_names = join_path(build_env_path, 'cray')
+
         if os.path.isdir(cray_wrapper_names):
             env.prepend_path('PATH', cray_wrapper_names)
             env.prepend_path('SPACK_ENV_PATH', cray_wrapper_names)

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -82,6 +82,10 @@ schema = {
                                 {'type': 'array',
                                  'items': {'type': 'string'}}],
                         },
+                        'craype_link_type': {
+                            'type': 'string',
+                            'default' : ''
+                        },
                     },
                 },
             },

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -25,7 +25,8 @@
 import os
 
 import pytest
-from spack import spack_root
+import spack
+from spack.platforms.cray import Cray
 from spack.environment import EnvironmentModifications
 from spack.environment import RemovePath, PrependPath, AppendPath
 from spack.environment import SetEnv, UnsetEnv
@@ -41,6 +42,7 @@ def prepare_environment_for_tests():
     os.environ['EMPTY_PATH_LIST'] = ''
     os.environ['PATH_LIST'] = '/path/second:/path/third'
     os.environ['REMOVE_PATH_LIST'] = '/a/b:/duplicate:/a/c:/remove/this:/a/d:/duplicate/:/f/g'  # NOQA: ignore=E501
+    os.environ["CRAYPE_LINK_TYPE"] = ""
     yield
     for x in ('UNSET_ME', 'EMPTY_PATH_LIST', 'PATH_LIST', 'REMOVE_PATH_LIST'):
         if x in os.environ:
@@ -83,7 +85,7 @@ def miscellaneous_paths():
 def files_to_be_sourced():
     """Returns a list of files to be sourced"""
     datadir = os.path.join(
-        spack_root, 'lib', 'spack', 'spack', 'test', 'data'
+        spack.spack_root, 'lib', 'spack', 'spack', 'test', 'data'
     )
 
     files = [
@@ -94,6 +96,13 @@ def files_to_be_sourced():
     ]
 
     return files
+
+
+def test_changing_link_type_on_cray(env):
+    pkg = spack.repo.get("mpich")
+    Cray().setup_platform_environment(pkg, env)
+    env.apply_modifications()
+    assert "static" == os.environ.get("CRAYPE_LINK_TYPE", "")
 
 
 def test_set(env):


### PR DESCRIPTION
Entry in packages.yaml to declare craype_link_type. Defaults to static since all: static. 