### PR TITLE
Add system cmake as the default

### DIFF
--- a/etc/spack/defaults/cray/packages.yaml
+++ b/etc/spack/defaults/cray/packages.yaml
@@ -88,3 +88,7 @@ packages:
             trilinos@12.10.1.1%intel: cray-trilinos
             trilinos@12.10.1.1%gcc+shared: cray-trilinos
             trilinos@12.10.1.1%intel+shared: cray-trilinos
+    cmake:
+        buildable: false
+        paths:
+            cmake: /usr/bin/cmake


### PR DESCRIPTION
Prevent having a combinatorial explosion of cmakes on our system.
Can override in personal packages.yaml if need to build update to date.