### PR TITLE
Remove python from packages.yaml

### DIFF
--- a/etc/spack/defaults/cray/packages.yaml
+++ b/etc/spack/defaults/cray/packages.yaml
@@ -60,11 +60,6 @@ packages:
             netcdf@4.4.1.1.3%intel+parallel-netcdf: cray-netcdf-hdf5parallel
             netcdf@4.4.1.1.3%gcc~parallel-netcdf: cray-netcdf
             netcdf@4.4.1.1.3%intel~parallel-netcdf: cray-netcdf
-    python:
-        buildable: false
-        modules:
-            python@2.7.13%gcc+shared: python
-            python@2.7.13%intel+shared: python
     petsc:
         buildable: false
         modules:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -133,6 +133,9 @@ class Python(AutotoolsPackage):
         spack_env.set('PYTHONPATH', prefix)
         spack_env.set('MACOSX_DEPLOYMENT_TARGET', platform.mac_ver()[0])
 
+        # Need this to properly build python on Cray without static linking
+        spack_env.set("CRAYPE_LINK_TYPE", "dynamic")
+
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Remove python from packages.yaml. The current modulefile for python has
two paths set to $PATH. This confuses Spack and leads to it picking up
the wrong executable (mpi4py) instead of the python exe.

For the python installation, ensure that we are doing dynamic linking
with python. Users will most likely need to specify ^python+shared for
anything that depends on python (direct deps only).