### PR TITLE
Add <include>/path/to/mpi in user-config.jam

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -226,9 +226,11 @@ class Boost(Package):
                 # that can be used as a compiler option instead.
 
                 mpi_line = 'using mpi : %s' % spec['mpi'].mpicxx
-
                 if 'platform=cray' in spec:
                     mpi_line += ' : <define>MPICH_SKIP_MPICXX'
+
+                mpi_line += " : <include>{0}".format(spec["mpi"].prefix.include)
+                mpi_line += " : <library-path>{0}".format(spec['mpi'].prefix.lib)
 
                 f.write(mpi_line + ' ;\n')
 


### PR DESCRIPTION
Boost would incorrectly located the MPI headers on Cray. To rectify
this, I added <include> path to user-config.jam. Tested on Cori.