### PR TITLE
Add new flag and fix libsigsegv

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -214,6 +214,9 @@ class Compiler(object):
             "If you think it should, please edit the compiler subclass and",
             "submit a pull request or issue.")
 
+    @property
+    def multiple_definition_flag(self):
+        return "-Wl,--allow-multiple-definition"
     #
     # Compiler classes have methods for querying the version of
     # specific compiler executables.  This is used when discovering compilers.

--- a/var/spack/repos/builtin/packages/libsigsegv/package.py
+++ b/var/spack/repos/builtin/packages/libsigsegv/package.py
@@ -32,7 +32,7 @@ class Libsigsegv(AutotoolsPackage):
     url      = "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.11.tar.gz"
 
     patch('patch.new_config_guess', when='@2.10')
-    
+
     variant("shared", default=True, description="Enable shared libraries")
     version('2.11', 'a812d9481f6097f705599b218eea349f')
     version('2.10', '7f96fb1f65b3b8cbc1582fb7be774f0f')
@@ -43,4 +43,6 @@ class Libsigsegv(AutotoolsPackage):
             args.append("--enable-shared")
         else:
             args.append("--disable-shared")
+        if "platform=cray" in self.spec and "~shared" in self.spec:
+            args.append("LDFLAGS={0}".format(self.compiler.multiple_definition_flag))
         return args


### PR DESCRIPTION
Added --allow-multiple-definition flag and also use it in the libsigsegv
package. The reason for this is because there is a specific order needed
when linking -lc and -lpthread. The cray compilers break this order
which causes a multiple definitions error. This flag bypasses this
error.