### PR TITLE
Add conditional to avoid adding mpi-prefix=

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -120,7 +120,8 @@ class Abinit(AutotoolsPackage):
         if '+mpi' in spec:
             # MPI version:
             # let the configure script auto-detect MPI support from mpi_prefix
-            oapp('--with-mpi-prefix={0}'.format(spec['mpi'].prefix))
+            if "platform=cray" not in spec:
+                oapp('--with-mpi-prefix={0}'.format(spec['mpi'].prefix))
             oapp('--enable-mpi=yes')
             oapp('--enable-mpi-io=yes')
 


### PR DESCRIPTION
Adding that line to configure would break the MPI tests