### PR TITLE
Ensure relative path returns a string (not None)

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -191,7 +191,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         _check_concrete(spec)
 
         if spec.external:
-            return spec.external_path
+            return spec.external_path or ''
 
         path = spec.format(self.path_scheme)
         return path


### PR DESCRIPTION
to prevent "'NoneType' has no method ..." errors when the relative path
is right here

this has bitten me enough times to prompt me to make a PR for it :)