### PR TITLE
Remove an import of non-existent function

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -60,8 +60,7 @@ from spack.util.environment import (
 from spack.util.environment import system_dirs
 from spack.error import NoLibrariesError, NoHeadersError
 from spack.util.executable import Executable
-from spack.util.module_cmd import (load_module, get_path_from_module,
-                                   unload_module)
+from spack.util.module_cmd import load_module, get_path_from_module
 from spack.util.log_parse import parse_log_events, make_log_context
 
 


### PR DESCRIPTION
Removes an import where unload_modules was present. This was defined in
our branch but not upstream, so it was leftover and causing errors.