### PR TITLE
Remove craype_link_type from schema

### DIFF
--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -52,10 +52,6 @@ properties = {
                                 'type':  'string',
                             },
                         },
-                        'craype_link_type': {
-                            'type': 'string',
-                            'default' : ''
-                        },
                     },
                     'modules': {
                         'type': 'object',


### PR DESCRIPTION
Keep this similar to the schema upstream. This was originally a way to
force spack to set craype_link_type to static but we are mainly using
dynamic as default.