### PR TITLE
Add unload_module function back

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -60,7 +60,8 @@ from spack.util.environment import (
 from spack.util.environment import system_dirs
 from spack.error import NoLibrariesError, NoHeadersError
 from spack.util.executable import Executable
-from spack.util.module_cmd import load_module, get_path_from_module
+from spack.util.module_cmd import (load_module, get_path_from_module,
+                                   unload_module)
 from spack.util.log_parse import parse_log_events, make_log_context
 
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -56,6 +56,11 @@ def module(*args):
         return str(module_p.communicate()[0].decode())
 
 
+def unload_module(mod):
+    """Takes a module name and removes the module"""
+    module("unload", mod)
+
+
 def load_module(mod):
     """Takes a module name and removes modules until it is possible to
     load that module. It then loads the provided module. Depends on the


### PR DESCRIPTION
This was originally removed from NERSC fork but is added back. The
assumption was that darshan and cray-libsci were being unloaded but
they were not. This should fix the import errors